### PR TITLE
로컬 로그인 로직 구현 및 복합키 변경

### DIFF
--- a/src/main/java/org/sesac/slopedbe/auth/controller/AuthController.java
+++ b/src/main/java/org/sesac/slopedbe/auth/controller/AuthController.java
@@ -1,5 +1,7 @@
 package org.sesac.slopedbe.auth.controller;
 
+import java.io.IOException;
+
 import org.sesac.slopedbe.auth.exception.MemberAlreadyExistsException;
 import org.sesac.slopedbe.auth.exception.MemberNotFoundException;
 import org.sesac.slopedbe.auth.model.CustomUserDetails;
@@ -29,6 +31,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -109,17 +112,33 @@ public class AuthController {
 		return ResponseEntity.ok("Email verified successfully");
 	}
 
+	// @GetMapping("/login/kakao")
+	// public String redirectToKakao(){
+	// 	return "redirect:http://localhost:8080/oauth2/authorization/kakao";
+	// }
+
+	// @GetMapping("/login/oauth2/code/kakao")
+	// public String getLoginInfo(OAuth2AuthenticationToken authentication) {
+	// 	// 인증 성공 후 처리 로직
+	// 	// Access Token을 이용해 사용자 정보를 가져오거나 추가 처리를 수행
+	// 	log.info("카카오 소셜 로그인 성공이요~");
+	// 	return "redirect:/";
+	// }
+
 	@GetMapping("/login/kakao")
-	public String redirectToKakao(){
-		return "redirect:http://localhost:3000/oauth2/authorization/kakao\"";
+	public void redirectToKakao(HttpServletResponse response) throws IOException {
+		response.sendRedirect("http://localhost:8080/oauth2/authorization/kakao");
 	}
 
+
 	@GetMapping("/login/oauth2/code/kakao")
-	public String getLoginInfo(OAuth2AuthenticationToken authentication) {
+	public void getLoginInfo(OAuth2AuthenticationToken authentication, HttpServletResponse response) throws
+		IOException {
 		// 인증 성공 후 처리 로직
 		// Access Token을 이용해 사용자 정보를 가져오거나 추가 처리를 수행
 		log.info("카카오 소셜 로그인 성공이요~");
-		return "redirect:/";
-	}
 
+		// 리다이렉트 처리
+		response.sendRedirect("http://localhost:3000/");
+	}
 }

--- a/src/main/java/org/sesac/slopedbe/auth/controller/AuthController.java
+++ b/src/main/java/org/sesac/slopedbe/auth/controller/AuthController.java
@@ -105,11 +105,7 @@ public class AuthController {
 		String id = request.id();
 
 		try {
-			if (id != null && !id.isEmpty()) {
-				verificationService.sendFindPasswordVerificationCode(id, email);
-			} else {
-				verificationService.sendFindIdVerificationCode(email);
-			}
+			verificationService.sendFindIdVerificationCode(email);
 			log.info("Received request to send verification code to: {}", email);
 			return ResponseEntity.status(HttpStatus.CREATED).body("Verification code sent to " + email);
 		} catch (MemberNotFoundException e) {

--- a/src/main/java/org/sesac/slopedbe/auth/controller/AuthController.java
+++ b/src/main/java/org/sesac/slopedbe/auth/controller/AuthController.java
@@ -39,6 +39,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/api/auth")
 @AllArgsConstructor
 @Slf4j
+
 public class AuthController {
 
 	private final VerificationService verificationService;
@@ -49,9 +50,12 @@ public class AuthController {
 
 	@PostMapping(value="/login", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<?> createAuthenticationToken(@RequestBody LoginRequest loginRequest) {
+		//Local Login용 method, memberId, password 받아 로그인 진행
+
 
 		log.info("Login attempt for user: {}", loginRequest.getMemberId());
 
+		// 로그인 - 실패시 error 별로 try-catch 문 진행
 		try {
 			Authentication authentication = authenticationManager.authenticate(
 				new UsernamePasswordAuthenticationToken(loginRequest.getMemberId(), loginRequest.getPassword())
@@ -76,6 +80,10 @@ public class AuthController {
 
 	@PostMapping("/send-code/verification-code")
 	public ResponseEntity<String> sendRegisterVerificationCode(@RequestBody MailVerificationRequest request) {
+		// Client에서 회원가입 중 이메일 인증 요청이 오면 메일로 인증코드 전송 (gmail 활용)
+		// 실제 전송 기능은 sendRegisterVerificationCode 에 포함, 여기선 성공, 실패 응답 반환
+		// email 전송할 때, 해당 이메일이 존재하면 실패 응답 반환
+
 		String email = request.email();
 
 		log.info("Received request to send verification code to: {}", email);
@@ -90,6 +98,9 @@ public class AuthController {
 
 	@PostMapping("/send-code/recovery-code")
 	public ResponseEntity<String> sendFindMemberVerificationCode(@RequestBody MailVerificationRequest request) {
+		// Client에서 아이디 찾기, 비밀번호 찾기 중 이메일 인증 요청이 오면 메일로 인증코드 전송 (gmail 활용)
+		// email 전송할 때, 해당 이메일이 존재하면 성공 응답 반환
+
 		String email = request.email();
 		String id = request.id();
 
@@ -108,25 +119,14 @@ public class AuthController {
 
 	@PostMapping("/verify-code")
 	public ResponseEntity<String> verifyCode(@RequestBody MailVerificationRequest request) {
+		// 저장된 인증 코드와 request 코드 검증 method
 		verificationService.verifyCode(request.email(), request.code());
 		return ResponseEntity.ok("Email verified successfully");
 	}
 
-	// @GetMapping("/login/kakao")
-	// public String redirectToKakao(){
-	// 	return "redirect:http://localhost:8080/oauth2/authorization/kakao";
-	// }
-
-	// @GetMapping("/login/oauth2/code/kakao")
-	// public String getLoginInfo(OAuth2AuthenticationToken authentication) {
-	// 	// 인증 성공 후 처리 로직
-	// 	// Access Token을 이용해 사용자 정보를 가져오거나 추가 처리를 수행
-	// 	log.info("카카오 소셜 로그인 성공이요~");
-	// 	return "redirect:/";
-	// }
-
 	@GetMapping("/login/kakao")
 	public void redirectToKakao(HttpServletResponse response) throws IOException {
+		// 카카오 로그인 페이지 전달
 		response.sendRedirect("http://localhost:8080/oauth2/authorization/kakao");
 	}
 

--- a/src/main/java/org/sesac/slopedbe/auth/controller/AuthController.java
+++ b/src/main/java/org/sesac/slopedbe/auth/controller/AuthController.java
@@ -3,9 +3,9 @@ package org.sesac.slopedbe.auth.controller;
 import org.sesac.slopedbe.auth.exception.MemberAlreadyExistsException;
 import org.sesac.slopedbe.auth.exception.MemberNotFoundException;
 import org.sesac.slopedbe.auth.model.CustomUserDetails;
-import org.sesac.slopedbe.auth.model.dto.JwtResponse;
-import org.sesac.slopedbe.auth.model.dto.LoginRequest;
-import org.sesac.slopedbe.auth.model.dto.MailVerificationRequest;
+import org.sesac.slopedbe.auth.model.dto.request.LoginRequest;
+import org.sesac.slopedbe.auth.model.dto.request.MailVerificationRequest;
+import org.sesac.slopedbe.auth.model.dto.response.JwtResponse;
 import org.sesac.slopedbe.auth.service.LoginServiceImpl;
 import org.sesac.slopedbe.auth.service.VerificationService;
 import org.sesac.slopedbe.auth.util.JwtUtil;
@@ -21,6 +21,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -40,6 +42,7 @@ public class AuthController {
 	private final AuthenticationManager authenticationManager;
 	private final JwtUtil jwtUtil;
 	private final LoginServiceImpl memberService;
+	private final OAuth2AuthorizedClientService authorizedClientService;
 
 	@PostMapping(value="/login", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<?> createAuthenticationToken(@RequestBody LoginRequest loginRequest) {
@@ -108,6 +111,15 @@ public class AuthController {
 
 	@GetMapping("/login/kakao")
 	public String redirectToKakao(){
-		return "redirect:/oauth2/authorization/kakao";
+		return "redirect:http://localhost:3000/oauth2/authorization/kakao\"";
 	}
+
+	@GetMapping("/login/oauth2/code/kakao")
+	public String getLoginInfo(OAuth2AuthenticationToken authentication) {
+		// 인증 성공 후 처리 로직
+		// Access Token을 이용해 사용자 정보를 가져오거나 추가 처리를 수행
+		log.info("카카오 소셜 로그인 성공이요~");
+		return "redirect:/";
+	}
+
 }

--- a/src/main/java/org/sesac/slopedbe/auth/controller/AuthController.java
+++ b/src/main/java/org/sesac/slopedbe/auth/controller/AuthController.java
@@ -21,6 +21,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -43,11 +44,11 @@ public class AuthController {
 	@PostMapping(value="/login", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<?> createAuthenticationToken(@RequestBody LoginRequest loginRequest) {
 
-		log.info("Login attempt for user: {}", loginRequest.getId());
+		log.info("Login attempt for user: {}", loginRequest.getMemberId());
 
 		try {
 			Authentication authentication = authenticationManager.authenticate(
-				new UsernamePasswordAuthenticationToken(loginRequest.getId(), loginRequest.getPassword())
+				new UsernamePasswordAuthenticationToken(loginRequest.getMemberId(), loginRequest.getPassword())
 			);
 			SecurityContextHolder.getContext().setAuthentication(authentication);
 		} catch (BadCredentialsException e) {
@@ -60,10 +61,10 @@ public class AuthController {
 			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Authentication failed");
 		}
 
-		final UserDetails userDetails = memberService.loadUserByUsername(loginRequest.getId());
+		final UserDetails userDetails = memberService.loadUserByUsername(loginRequest.getMemberId());
 		final String jwt = jwtUtil.generateToken((CustomUserDetails)userDetails);
 
-		log.info("JWT generated for user {}: {}", loginRequest.getId(), jwt);
+		log.info("JWT generated for user {}: {}", loginRequest.getMemberId(), jwt);
 		return ResponseEntity.ok(new JwtResponse(jwt));
 	}
 
@@ -103,5 +104,10 @@ public class AuthController {
 	public ResponseEntity<String> verifyCode(@RequestBody MailVerificationRequest request) {
 		verificationService.verifyCode(request.email(), request.code());
 		return ResponseEntity.ok("Email verified successfully");
+	}
+
+	@GetMapping("/login/kakao")
+	public String redirectToKakao(){
+		return "redirect:/oauth2/authorization/kakao";
 	}
 }

--- a/src/main/java/org/sesac/slopedbe/auth/filter/JwtRequestFilter.java
+++ b/src/main/java/org/sesac/slopedbe/auth/filter/JwtRequestFilter.java
@@ -37,6 +37,10 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 		return path.startsWith("/api/auth/") ||
 			path.startsWith("/api/users/") ||
 			"/joinpage".equals(path) ||
+			path.startsWith("/swagger-resources") ||
+			path.startsWith("/swagger-ui") ||
+			path.startsWith("/v3/api-docs") ||
+			path.startsWith("/webjars") ||
 			path.startsWith("/login/");
 	}
 

--- a/src/main/java/org/sesac/slopedbe/auth/filter/JwtRequestFilter.java
+++ b/src/main/java/org/sesac/slopedbe/auth/filter/JwtRequestFilter.java
@@ -34,7 +34,10 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 	@Override
 	protected boolean shouldNotFilter(HttpServletRequest request) {
 		String path = request.getRequestURI();
-		return path.startsWith("/api/auth/") || "/api/users/register".equals(path);
+		return path.startsWith("/api/auth/") ||
+			path.startsWith("/api/users/") ||
+			"/joinpage".equals(path) ||
+			path.startsWith("/login/");
 	}
 
 	@Override

--- a/src/main/java/org/sesac/slopedbe/auth/model/dto/LoginRequest.java
+++ b/src/main/java/org/sesac/slopedbe/auth/model/dto/LoginRequest.java
@@ -4,6 +4,6 @@ import lombok.Getter;
 
 @Getter
 public class LoginRequest {
-	private String id;
+	private String memberId;
 	private String password;
 }

--- a/src/main/java/org/sesac/slopedbe/auth/model/dto/SocialLoginInfoDTO.java
+++ b/src/main/java/org/sesac/slopedbe/auth/model/dto/SocialLoginInfoDTO.java
@@ -1,0 +1,17 @@
+package org.sesac.slopedbe.auth.model.dto;
+
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class SocialLoginInfoDTO {
+	private String email;
+	private String socialAuthCode;
+	private String socialOauthType;
+	private Map<String, Object> attributes;
+}

--- a/src/main/java/org/sesac/slopedbe/auth/model/dto/request/LoginRequest.java
+++ b/src/main/java/org/sesac/slopedbe/auth/model/dto/request/LoginRequest.java
@@ -1,4 +1,4 @@
-package org.sesac.slopedbe.auth.model.dto;
+package org.sesac.slopedbe.auth.model.dto.request;
 
 import lombok.Getter;
 

--- a/src/main/java/org/sesac/slopedbe/auth/model/dto/request/MailVerificationRequest.java
+++ b/src/main/java/org/sesac/slopedbe/auth/model/dto/request/MailVerificationRequest.java
@@ -1,4 +1,4 @@
-package org.sesac.slopedbe.auth.model.dto;
+package org.sesac.slopedbe.auth.model.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/org/sesac/slopedbe/auth/model/dto/response/JwtResponse.java
+++ b/src/main/java/org/sesac/slopedbe/auth/model/dto/response/JwtResponse.java
@@ -1,4 +1,4 @@
-package org.sesac.slopedbe.auth.model.dto;
+package org.sesac.slopedbe.auth.model.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/org/sesac/slopedbe/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/org/sesac/slopedbe/auth/service/CustomOAuth2UserService.java
@@ -1,0 +1,13 @@
+package org.sesac.slopedbe.auth.service;
+
+import java.util.Map;
+
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+public interface CustomOAuth2UserService extends OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+	// OAuth2User loadUser(OAuth2UserRequest userRequest);
+	String getkakaoEmail(Map<String, Object> paramMap);
+}

--- a/src/main/java/org/sesac/slopedbe/auth/service/CustomOAuth2UserServiceImpl.java
+++ b/src/main/java/org/sesac/slopedbe/auth/service/CustomOAuth2UserServiceImpl.java
@@ -1,0 +1,54 @@
+package org.sesac.slopedbe.auth.service;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.sesac.slopedbe.member.model.entity.Member;
+import org.sesac.slopedbe.member.repository.MemberRepository;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class CustomOAuth2UserServiceImpl extends DefaultOAuth2UserService implements CustomOAuth2UserService {
+
+	private final MemberRepository memberRepository;
+
+	@Override
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+		OAuth2User oAuth2User = super.loadUser(userRequest);
+		Map<String, Object> paramMap = oAuth2User.getAttributes();
+
+		String email = getkakaoEmail(paramMap);
+		log.info("Extracted email:"+ email);
+
+		Optional<Member> memberOpt = memberRepository.findByEmail(email);
+		if (memberOpt.isEmpty()) {
+			//소셜 로그인 가입
+
+		}
+
+		return oAuth2User;
+	}
+
+	@Override
+	public String getkakaoEmail(Map<String, Object> paramMap) {
+
+		Object value = paramMap.get("kakao_account");
+
+		LinkedHashMap accountMap = (LinkedHashMap) value;
+		String email = (String)accountMap.get("email");
+
+		log.info("email :" + email);
+
+		return email;
+	}
+}

--- a/src/main/java/org/sesac/slopedbe/auth/service/CustomOAuth2UserServiceImpl.java
+++ b/src/main/java/org/sesac/slopedbe/auth/service/CustomOAuth2UserServiceImpl.java
@@ -33,7 +33,7 @@ public class CustomOAuth2UserServiceImpl extends DefaultOAuth2UserService implem
 		Optional<Member> memberOpt = memberRepository.findByEmail(email);
 		if (memberOpt.isEmpty()) {
 			//소셜 로그인 가입
-
+			log.info("소셜 아이디 가입 필요");
 		}
 
 		return oAuth2User;

--- a/src/main/java/org/sesac/slopedbe/auth/service/CustomOAuth2UserServiceImpl.java
+++ b/src/main/java/org/sesac/slopedbe/auth/service/CustomOAuth2UserServiceImpl.java
@@ -5,6 +5,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.sesac.slopedbe.member.model.entity.Member;
+import org.sesac.slopedbe.member.model.entity.MemberCompositeKey;
+import org.sesac.slopedbe.member.model.type.MemberOauthType;
 import org.sesac.slopedbe.member.repository.MemberRepository;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -30,10 +32,12 @@ public class CustomOAuth2UserServiceImpl extends DefaultOAuth2UserService implem
 		String email = getkakaoEmail(paramMap);
 		log.info("Extracted email:"+ email);
 
-		Optional<Member> memberOpt = memberRepository.findByEmail(email);
+		MemberOauthType oauthType = MemberOauthType.KAKAO;
+
+		Optional<Member> memberOpt = memberRepository.findById(new MemberCompositeKey(email,oauthType));
 		if (memberOpt.isEmpty()) {
 			//소셜 로그인 가입
-			log.info("소셜 아이디 가입 필요");
+			log.info("소셜 아이디 가입 필요(카카오)");
 		}
 
 		return oAuth2User;

--- a/src/main/java/org/sesac/slopedbe/auth/service/LoginServiceImpl.java
+++ b/src/main/java/org/sesac/slopedbe/auth/service/LoginServiceImpl.java
@@ -24,6 +24,8 @@ public class LoginServiceImpl implements UserDetailsService {
 
 	@Override
 	public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+		// memberId로 사용자 검색, 검색된 사용자, memberRole 반환
+
 		Member member = memberRepository.findByMemberId(userId)
 			.orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 		return new CustomUserDetails(member, getAuthorities(member));

--- a/src/main/java/org/sesac/slopedbe/auth/service/VerificationService.java
+++ b/src/main/java/org/sesac/slopedbe/auth/service/VerificationService.java
@@ -9,5 +9,4 @@ public interface VerificationService {
 	void verifyCode(String email, String code);
 	void sendRegisterVerificationCode(String email);
 	void sendFindIdVerificationCode(String email);
-	void sendFindPasswordVerificationCode(String id, String email);
 }

--- a/src/main/java/org/sesac/slopedbe/auth/service/VerificationService.java
+++ b/src/main/java/org/sesac/slopedbe/auth/service/VerificationService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 
 public interface VerificationService {
 
-	public void verifyCode(String email, String code);
+	void verifyCode(String email, String code);
 	void sendRegisterVerificationCode(String email);
 	void sendFindIdVerificationCode(String email);
 	void sendFindPasswordVerificationCode(String id, String email);

--- a/src/main/java/org/sesac/slopedbe/auth/service/VerificationServiceImpl.java
+++ b/src/main/java/org/sesac/slopedbe/auth/service/VerificationServiceImpl.java
@@ -8,6 +8,8 @@ import org.sesac.slopedbe.auth.exception.AuthException;
 import org.sesac.slopedbe.auth.exception.MemberNotFoundException;
 import org.sesac.slopedbe.member.exception.MemberErrorCode;
 import org.sesac.slopedbe.member.exception.MemberException;
+import org.sesac.slopedbe.member.model.entity.MemberCompositeKey;
+import org.sesac.slopedbe.member.model.type.MemberOauthType;
 import org.sesac.slopedbe.member.repository.MemberRepository;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mail.SimpleMailMessage;
@@ -60,8 +62,10 @@ public class VerificationServiceImpl implements VerificationService {
 	public void sendRegisterVerificationCode(String email) {
 		// 회원 가입용 인증 코드 포함, 인증 메일 전송 method
 
+		MemberOauthType oauthType = MemberOauthType.LOCAL;
+
 		// 이메일 이미 존재하면 오류
-		if (memberRepository.existsByEmail(email)) {
+		if (memberRepository.existsById(new MemberCompositeKey(email, oauthType))) {
 			throw new MemberException(MemberErrorCode.MEMBER_EMAIL_ALREADY_EXISTS);
 		}
 		// 인증 코드 생성
@@ -76,8 +80,10 @@ public class VerificationServiceImpl implements VerificationService {
 	public void sendFindIdVerificationCode(String email) {
 		// 아이디 찾기 용 인증 코드 포함, 인증 메일 전송 method
 
+		MemberOauthType oauthType = MemberOauthType.LOCAL;
+
 		// 이메일 존재하지 않으면 오류
-		if (memberRepository.findByEmail(email).isEmpty()) {
+		if (memberRepository.findById(new MemberCompositeKey(email, oauthType)).isEmpty()) {
 			throw new MemberNotFoundException("해당 이메일이 검색되지 않습니다.");
 		}
 
@@ -90,16 +96,16 @@ public class VerificationServiceImpl implements VerificationService {
 	}
 
 
-	@Override
-	public void sendFindPasswordVerificationCode(String id, String email) {
-		//비밀번호 찾기 용도
-		//이 메서드는 Id 찾기 sendFindIdVerificationCode method와 병합 예정
-
-		if (memberRepository.findByEmail(email).isEmpty() || memberRepository.findByMemberId(id).isEmpty()) {
-			throw new MemberNotFoundException("해당 아이디 또는 이메일이 조회되지 않습니다.");
-		}
-		String code = generateVerificationCode();
-		saveVerificationCode(email, code);
-		sendVerificationEmail(email, code);
-	}
+	// @Override
+	// public void sendFindPasswordVerificationCode(String id, String email) {
+	// 	//비밀번호 찾기 용도
+	// 	//이 메서드는 Id 찾기 sendFindIdVerificationCode method와 병합 예정
+	//
+	// 	if (memberRepository.findByEmail(email).isEmpty() || memberRepository.findByMemberId(id).isEmpty()) {
+	// 		throw new MemberNotFoundException("해당 아이디 또는 이메일이 조회되지 않습니다.");
+	// 	}
+	// 	String code = generateVerificationCode();
+	// 	saveVerificationCode(email, code);
+	// 	sendVerificationEmail(email, code);
+	// }
 }

--- a/src/main/java/org/sesac/slopedbe/bookmark/model/entity/Bookmark.java
+++ b/src/main/java/org/sesac/slopedbe/bookmark/model/entity/Bookmark.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinColumns;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -27,6 +28,9 @@ public class Bookmark extends BaseTimeEntity {
 
     @Id
     @ManyToOne
-    @JoinColumn(name = "email", nullable = false)
+    @JoinColumns({
+        @JoinColumn(name = "email", referencedColumnName = "email"),
+        @JoinColumn(name = "oauthType", referencedColumnName = "oauthType")
+    })
     private Member member;
 }

--- a/src/main/java/org/sesac/slopedbe/config/SecurityConfig.java
+++ b/src/main/java/org/sesac/slopedbe/config/SecurityConfig.java
@@ -34,12 +34,17 @@ public class SecurityConfig {
 			.csrf(AbstractHttpConfigurer::disable)  // CSRF 보호 비활성화
 			.authorizeHttpRequests(authorizeRequests ->
 				authorizeRequests
-					.requestMatchers("/login",  "/api/auth/**","/api/users/**" ).permitAll()
+					.requestMatchers("/joinpage", "/login/**",  "/api/auth/**","/api/users/**" ).permitAll()
 					.anyRequest().authenticated()
 			)
 			.sessionManagement(sessionManagement ->
 				sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-			);
+			)
+			// .oauth2Login(oauth2 ->
+			// 	oauth2.loginPage("/joinpage")
+			// )
+		;
+
 
 		return http.build();
 	}

--- a/src/main/java/org/sesac/slopedbe/config/SecurityConfig.java
+++ b/src/main/java/org/sesac/slopedbe/config/SecurityConfig.java
@@ -44,11 +44,10 @@ public class SecurityConfig {
 			.oauth2Login(oauth2 ->
 				oauth2
 					.loginPage("http://localhost:3000/joinpage")
-					.defaultSuccessUrl("http://localhost:3000/")
+					.defaultSuccessUrl("/api/auth/login/oauth2/code/kakao")
 					.failureUrl("http://localhost:3000/login?error=true")
 					// .successHandler(successHandler())
-			)
-		;
+			);
 
 		return http.build();
 	}

--- a/src/main/java/org/sesac/slopedbe/config/SecurityConfig.java
+++ b/src/main/java/org/sesac/slopedbe/config/SecurityConfig.java
@@ -34,17 +34,21 @@ public class SecurityConfig {
 			.csrf(AbstractHttpConfigurer::disable)  // CSRF 보호 비활성화
 			.authorizeHttpRequests(authorizeRequests ->
 				authorizeRequests
-					.requestMatchers("/joinpage", "/login/**",  "/api/auth/**","/api/users/**" ).permitAll()
+					.requestMatchers("/joinpage", "/login/**",  "/api/auth/**","/api/users/**"
+					,"/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**", "/webjars/**").permitAll()
 					.anyRequest().authenticated()
 			)
 			.sessionManagement(sessionManagement ->
 				sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			)
-			// .oauth2Login(oauth2 ->
-			// 	oauth2.loginPage("/joinpage")
-			// )
+			.oauth2Login(oauth2 ->
+				oauth2
+					.loginPage("http://localhost:3000/joinpage")
+					.defaultSuccessUrl("http://localhost:3000/")
+					.failureUrl("http://localhost:3000/login?error=true")
+					// .successHandler(successHandler())
+			)
 		;
-
 
 		return http.build();
 	}
@@ -66,6 +70,17 @@ public class SecurityConfig {
 	public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
 		return authenticationConfiguration.getAuthenticationManager();
 	}
+
+	// @Bean
+	// //테스트용!!
+	// public SimpleUrlAuthenticationSuccessHandler successHandler() {
+	// 	SimpleUrlAuthenticationSuccessHandler handler = new SimpleUrlAuthenticationSuccessHandler();
+	// 	log.info("소셜 로그인 성공!");
+	// 	handler.setDefaultTargetUrl("http://localhost:3000/joinpage");  // 성공 후 리다이렉트 URL 설정
+	// 	return handler;
+	// }
+
+
 
 }
 

--- a/src/main/java/org/sesac/slopedbe/facility/model/entity/FacilityRegistrar.java
+++ b/src/main/java/org/sesac/slopedbe/facility/model/entity/FacilityRegistrar.java
@@ -1,11 +1,18 @@
 package org.sesac.slopedbe.facility.model.entity;
 
-import jakarta.persistence.*;
+import org.sesac.slopedbe.common.entity.BaseTimeEntity;
+import org.sesac.slopedbe.member.model.entity.Member;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinColumns;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.sesac.slopedbe.common.entity.BaseTimeEntity;
-import org.sesac.slopedbe.member.model.entity.Member;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -20,6 +27,9 @@ public class FacilityRegistrar extends BaseTimeEntity {
 
     @Id
     @ManyToOne
-    @JoinColumn(name = "email", nullable = false)
+    @JoinColumns({
+        @JoinColumn(name = "email", referencedColumnName = "email"),
+        @JoinColumn(name = "oauthType", referencedColumnName = "oauthType")
+    })
     private Member member;
 }

--- a/src/main/java/org/sesac/slopedbe/facilityreport/model/entity/FacilityReport.java
+++ b/src/main/java/org/sesac/slopedbe/facilityreport/model/entity/FacilityReport.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinColumns;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -24,6 +25,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "facility_report")
 @Entity
 public class FacilityReport extends BaseTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -51,6 +53,9 @@ public class FacilityReport extends BaseTimeEntity {
     private Facility facility;
 
     @ManyToOne
-    @JoinColumn(name = "email", nullable = false)
+    @JoinColumns({
+        @JoinColumn(name = "email", referencedColumnName = "email"),
+        @JoinColumn(name = "oauthType", referencedColumnName = "oauthType")
+    })
     private Member member;
 }

--- a/src/main/java/org/sesac/slopedbe/facilityreview/model/entity/FacilityReview.java
+++ b/src/main/java/org/sesac/slopedbe/facilityreview/model/entity/FacilityReview.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinColumns;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -37,6 +38,9 @@ public class FacilityReview extends BaseTimeEntity {
     private Facility facility;
 
     @ManyToOne
-    @JoinColumn(name = "email", nullable = false)
+    @JoinColumns({
+        @JoinColumn(name = "email", referencedColumnName = "email"),
+        @JoinColumn(name = "oauthType", referencedColumnName = "oauthType")
+    })
     private Member member;
 }

--- a/src/main/java/org/sesac/slopedbe/member/controller/MemberController.java
+++ b/src/main/java/org/sesac/slopedbe/member/controller/MemberController.java
@@ -34,24 +34,28 @@ public class MemberController {
 
     @PostMapping("/duplicate-check/id")
     public ResponseEntity<String> checkDuplicateId(@Valid @RequestBody CheckDuplicateIdRequest checkDuplicateIdRequest) {
+        // 회원 가입, 아이디 찾기 시 중복 아이디 검사 용도
         memberService.checkDuplicateId(checkDuplicateIdRequest.id());
         return ResponseEntity.noContent().build();
     }
 
     @PutMapping("")
     public ResponseEntity<Member> updateMemberInfo(@RequestParam String email, @RequestParam String newNickname, @RequestParam String newPassword, boolean newDisability) {
+        // 마이페이지에서 회원 정보 수정 기능 용도
         Member updatedMember = memberService.updateMemberInfo(email, newNickname, newPassword, newDisability);
         return ResponseEntity.ok(updatedMember);
     }
 
     @DeleteMapping("")
     public ResponseEntity<Void> deleteMember(@RequestParam String email) {
+        // 마이 페이지, 회원 탈퇴 용도
         memberService.deleteMember(email);
         return ResponseEntity.noContent().build();
     }
 
     @PutMapping("/blacklist")
     public ResponseEntity<Member> updateStatus(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestParam String email, @RequestParam MemberStatus status) {
+        // 관리자 페이지, Status를 수정해 회원 정지 용도
         log.info("User {} updated status of member {} to {}", userDetails.getUsername(), email, status);
 
         Member updatedMember = memberService.updateMemberStatus(email, status);
@@ -60,12 +64,14 @@ public class MemberController {
 
     @PostMapping("/register")
     public ResponseEntity<RegisterMemberResponse> register(@Valid @RequestBody RegisterMemberRequest request) {
+        // 회원 가입
         Member savedMember = memberService.registerMember(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(new RegisterMemberResponse(savedMember.getEmail()));
     }
 
     @PostMapping("/find-id")
     public ResponseEntity<String> findIdByEmail(@Valid @RequestBody EmailRequest emailRequest) {
+        // 아이디 찾기
         String email = emailRequest.email();
         String memberId = memberService.findMemberIdByEmail(email);
         return ResponseEntity.ok(memberId);
@@ -73,6 +79,7 @@ public class MemberController {
 
     @PutMapping("/request-reset")
     public ResponseEntity<Member> updatePassword(@RequestBody UpdateRequest updateRequest){
+        // 비밀 번호 찾기, 비밀 번호 재설정 method
         Member updatedMember = memberService.updateMemberPassword(updateRequest.getMemberId(), updateRequest.getNewPassword());
         return ResponseEntity.ok(updatedMember);
     }

--- a/src/main/java/org/sesac/slopedbe/member/controller/MemberController.java
+++ b/src/main/java/org/sesac/slopedbe/member/controller/MemberController.java
@@ -1,9 +1,9 @@
 package org.sesac.slopedbe.member.controller;
 
 import org.sesac.slopedbe.auth.model.CustomUserDetails;
-import org.sesac.slopedbe.auth.model.dto.MailVerificationRequest;
 import org.sesac.slopedbe.member.model.dto.UpdateRequest;
 import org.sesac.slopedbe.member.model.dto.request.CheckDuplicateIdRequest;
+import org.sesac.slopedbe.member.model.dto.request.EmailRequest;
 import org.sesac.slopedbe.member.model.dto.request.RegisterMemberRequest;
 import org.sesac.slopedbe.member.model.dto.response.RegisterMemberResponse;
 import org.sesac.slopedbe.member.model.entity.Member;
@@ -38,13 +38,6 @@ public class MemberController {
         return ResponseEntity.noContent().build();
     }
 
-    @PostMapping("/find-id")
-    public ResponseEntity<String> findIdByEmail(@Valid @RequestBody MailVerificationRequest mailVerificationRequest) {
-        String email = mailVerificationRequest.email();
-        String id = memberService.findIdByEmail(email);
-        return ResponseEntity.ok(id);
-    }
-
     @PutMapping("")
     public ResponseEntity<Member> updateMemberInfo(@RequestParam String email, @RequestParam String newNickname, @RequestParam String newPassword, boolean newDisability) {
         Member updatedMember = memberService.updateMemberInfo(email, newNickname, newPassword, newDisability);
@@ -69,6 +62,13 @@ public class MemberController {
     public ResponseEntity<RegisterMemberResponse> register(@Valid @RequestBody RegisterMemberRequest request) {
         Member savedMember = memberService.registerMember(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(new RegisterMemberResponse(savedMember.getEmail()));
+    }
+
+    @PostMapping("/find-id")
+    public ResponseEntity<String> findIdByEmail(@Valid @RequestBody EmailRequest emailRequest) {
+        String email = emailRequest.email();
+        String id = memberService.findIdByEmail(email);
+        return ResponseEntity.ok(id);
     }
 
     @PutMapping("/request-reset")

--- a/src/main/java/org/sesac/slopedbe/member/controller/MemberController.java
+++ b/src/main/java/org/sesac/slopedbe/member/controller/MemberController.java
@@ -1,10 +1,10 @@
 package org.sesac.slopedbe.member.controller;
 
 import org.sesac.slopedbe.auth.model.CustomUserDetails;
-import org.sesac.slopedbe.member.model.dto.UpdateRequest;
 import org.sesac.slopedbe.member.model.dto.request.CheckDuplicateIdRequest;
 import org.sesac.slopedbe.member.model.dto.request.EmailRequest;
 import org.sesac.slopedbe.member.model.dto.request.RegisterMemberRequest;
+import org.sesac.slopedbe.member.model.dto.request.UpdateRequest;
 import org.sesac.slopedbe.member.model.dto.response.RegisterMemberResponse;
 import org.sesac.slopedbe.member.model.entity.Member;
 import org.sesac.slopedbe.member.model.type.MemberStatus;
@@ -67,13 +67,13 @@ public class MemberController {
     @PostMapping("/find-id")
     public ResponseEntity<String> findIdByEmail(@Valid @RequestBody EmailRequest emailRequest) {
         String email = emailRequest.email();
-        String id = memberService.findIdByEmail(email);
-        return ResponseEntity.ok(id);
+        String memberId = memberService.findMemberIdByEmail(email);
+        return ResponseEntity.ok(memberId);
     }
 
     @PutMapping("/request-reset")
     public ResponseEntity<Member> updatePassword(@RequestBody UpdateRequest updateRequest){
-        Member updatedMember = memberService.updateMemberPassword(updateRequest.getId(), updateRequest.getNewPassword());
+        Member updatedMember = memberService.updateMemberPassword(updateRequest.getMemberId(), updateRequest.getNewPassword());
         return ResponseEntity.ok(updatedMember);
     }
 }

--- a/src/main/java/org/sesac/slopedbe/member/controller/MemberController.java
+++ b/src/main/java/org/sesac/slopedbe/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package org.sesac.slopedbe.member.controller;
 import org.sesac.slopedbe.auth.model.CustomUserDetails;
 import org.sesac.slopedbe.member.model.dto.request.CheckDuplicateIdRequest;
 import org.sesac.slopedbe.member.model.dto.request.EmailRequest;
+import org.sesac.slopedbe.member.model.dto.request.IdRequest;
 import org.sesac.slopedbe.member.model.dto.request.RegisterMemberRequest;
 import org.sesac.slopedbe.member.model.dto.request.UpdateRequest;
 import org.sesac.slopedbe.member.model.dto.response.RegisterMemberResponse;
@@ -40,25 +41,25 @@ public class MemberController {
     }
 
     @PutMapping("")
-    public ResponseEntity<Member> updateMemberInfo(@RequestParam String email, @RequestParam String newNickname, @RequestParam String newPassword, boolean newDisability) {
+    public ResponseEntity<Member> updateMemberInfo(@RequestParam IdRequest idRequest, @RequestParam String newNickname, @RequestParam String newPassword, boolean newDisability) {
         // 마이페이지에서 회원 정보 수정 기능 용도
-        Member updatedMember = memberService.updateMemberInfo(email, newNickname, newPassword, newDisability);
+        Member updatedMember = memberService.updateMemberInfo(idRequest, newNickname, newPassword, newDisability);
         return ResponseEntity.ok(updatedMember);
     }
 
     @DeleteMapping("")
-    public ResponseEntity<Void> deleteMember(@RequestParam String email) {
+    public ResponseEntity<Void> deleteMember(@RequestParam IdRequest idRequest) {
         // 마이 페이지, 회원 탈퇴 용도
-        memberService.deleteMember(email);
+        memberService.deleteMember(idRequest);
         return ResponseEntity.noContent().build();
     }
 
     @PutMapping("/blacklist")
-    public ResponseEntity<Member> updateStatus(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestParam String email, @RequestParam MemberStatus status) {
+    public ResponseEntity<Member> updateStatus(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestParam IdRequest idRequest, @RequestParam MemberStatus status) {
         // 관리자 페이지, Status를 수정해 회원 정지 용도
-        log.info("User {} updated status of member {} to {}", userDetails.getUsername(), email, status);
+        log.info("User {} updated status of member {} to {}", userDetails.getUsername(), idRequest, status);
 
-        Member updatedMember = memberService.updateMemberStatus(email, status);
+        Member updatedMember = memberService.updateMemberStatus(idRequest, status);
         return ResponseEntity.ok(updatedMember);
     }
 
@@ -70,7 +71,7 @@ public class MemberController {
     }
 
     @PostMapping("/find-id")
-    public ResponseEntity<String> findIdByEmail(@Valid @RequestBody EmailRequest emailRequest) {
+    public ResponseEntity<String> findMemberIdByEmail(@Valid @RequestBody EmailRequest emailRequest) {
         // 아이디 찾기
         String email = emailRequest.email();
         String memberId = memberService.findMemberIdByEmail(email);

--- a/src/main/java/org/sesac/slopedbe/member/model/dto/request/EmailRequest.java
+++ b/src/main/java/org/sesac/slopedbe/member/model/dto/request/EmailRequest.java
@@ -1,0 +1,8 @@
+package org.sesac.slopedbe.member.model.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailRequest(
+	@NotBlank(message = "이메일를 입력해주세요")
+	String email
+){}

--- a/src/main/java/org/sesac/slopedbe/member/model/dto/request/IdRequest.java
+++ b/src/main/java/org/sesac/slopedbe/member/model/dto/request/IdRequest.java
@@ -1,0 +1,12 @@
+package org.sesac.slopedbe.member.model.dto.request;
+
+import org.sesac.slopedbe.member.model.type.MemberOauthType;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record IdRequest(
+	@NotBlank(message = "이메일를 입력해주세요")
+	String email,
+	@NotBlank(message = "회원 타입을 입력해주세요")
+	MemberOauthType oauthType
+){}

--- a/src/main/java/org/sesac/slopedbe/member/model/dto/request/UpdateRequest.java
+++ b/src/main/java/org/sesac/slopedbe/member/model/dto/request/UpdateRequest.java
@@ -1,4 +1,4 @@
-package org.sesac.slopedbe.member.model.dto;
+package org.sesac.slopedbe.member.model.dto.request;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -7,8 +7,7 @@ import lombok.Setter;
 @Setter
 public class UpdateRequest {
 	private String email;
-	private String code;
-	private String id;
+	private String memberId;
 	private String newPassword;
 }
 

--- a/src/main/java/org/sesac/slopedbe/member/model/entity/Member.java
+++ b/src/main/java/org/sesac/slopedbe/member/model/entity/Member.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Email;
 import lombok.AllArgsConstructor;
@@ -23,12 +24,18 @@ import lombok.Setter;
 @AllArgsConstructor
 @Table(name = "member")
 @Entity
+@IdClass(MemberCompositeKey.class)
 public class Member extends BaseTimeEntity {
 
     @Id
     @Column(nullable = false, unique = true, length = 200)
     @Email
     private String email;
+
+    @Id
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MemberOauthType oauthType;
 
     @Column(nullable = false, length = 20)
     private String nickname;
@@ -45,9 +52,6 @@ public class Member extends BaseTimeEntity {
 
     @Column()
     private String refreshToken;
-
-    @Enumerated(EnumType.STRING)
-    private MemberOauthType oauthType;
 
     @Column(unique = true)
     private String memberId;
@@ -69,5 +73,6 @@ public class Member extends BaseTimeEntity {
         this.isDisability = isDisabled;
         this.memberRole = MemberRole.USER;
         this.memberStatus = MemberStatus.ACTIVE;
+        this.oauthType = MemberOauthType.LOCAL;
     }
 }

--- a/src/main/java/org/sesac/slopedbe/member/model/entity/MemberCompositeKey.java
+++ b/src/main/java/org/sesac/slopedbe/member/model/entity/MemberCompositeKey.java
@@ -1,0 +1,23 @@
+package org.sesac.slopedbe.member.model.entity;
+
+import java.io.Serializable;
+
+import org.sesac.slopedbe.member.model.type.MemberOauthType;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class MemberCompositeKey implements Serializable {
+
+	private String email;
+	private MemberOauthType oauthType;
+
+}

--- a/src/main/java/org/sesac/slopedbe/member/model/type/MemberOauthType.java
+++ b/src/main/java/org/sesac/slopedbe/member/model/type/MemberOauthType.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum MemberOauthType {
+	LOCAL("TYPE_LOCAL"),
+	NAVER("TYPE_NAVER"),
 	KAKAO("TYPE_KAKAO"),
 	GOOGLE("TYPE_GOOGLE");
 

--- a/src/main/java/org/sesac/slopedbe/member/model/type/MemberOauthType.java
+++ b/src/main/java/org/sesac/slopedbe/member/model/type/MemberOauthType.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum MemberOauthType {
-	NAVER("TYPE_NAVER"),
+	KAKAO("TYPE_KAKAO"),
 	GOOGLE("TYPE_GOOGLE");
 
 	private final String value;

--- a/src/main/java/org/sesac/slopedbe/member/model/type/MemberRole.java
+++ b/src/main/java/org/sesac/slopedbe/member/model/type/MemberRole.java
@@ -9,6 +9,5 @@ public enum MemberRole {
 	ADMIN("ROLE_ADMIN"),
 	USER("ROLE_USER");
 
-
 	private final String value;
 }

--- a/src/main/java/org/sesac/slopedbe/member/repository/MemberRepository.java
+++ b/src/main/java/org/sesac/slopedbe/member/repository/MemberRepository.java
@@ -3,14 +3,20 @@ package org.sesac.slopedbe.member.repository;
 import java.util.Optional;
 
 import org.sesac.slopedbe.member.model.entity.Member;
+import org.sesac.slopedbe.member.model.entity.MemberCompositeKey;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
-	Optional<Member> findByEmail(String email);
+public interface MemberRepository extends JpaRepository<Member, MemberCompositeKey> {
+
 	Optional<Member> findByMemberId(String memberId);
-	void deleteByEmail(String email);
 
 	boolean existsByMemberId(String memberId);
 
 	boolean existsByEmail(String email);
+
+
+	// 아래 메서드들은 JpaRepository에 이미 존재.
+	// void deleteById(MemberCompositeKey memberCompositeKey);
+	// boolean existsById(MemberCompositeKey memberCompositeKey);
+	// Optional<Member> findById(MemberCompositeKey memberCompositeKey);
 }

--- a/src/main/java/org/sesac/slopedbe/member/repository/MemberRepository.java
+++ b/src/main/java/org/sesac/slopedbe/member/repository/MemberRepository.java
@@ -7,10 +7,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 	Optional<Member> findByEmail(String email);
-	Optional<Member> findByMemberId(String id);
+	Optional<Member> findByMemberId(String memberId);
 	void deleteByEmail(String email);
 
-	boolean existsByMemberId(String id);
+	boolean existsByMemberId(String memberId);
 
 	boolean existsByEmail(String email);
 }

--- a/src/main/java/org/sesac/slopedbe/member/service/MemberService.java
+++ b/src/main/java/org/sesac/slopedbe/member/service/MemberService.java
@@ -7,13 +7,13 @@ import org.sesac.slopedbe.member.model.type.MemberStatus;
 public interface MemberService {
     Member registerMember(RegisterMemberRequest registerMemberRequest);
 
-    void checkDuplicateId(String id);
+    void checkDuplicateId(String memberId);
 
     String findIdByEmail(String email);
 
     void deleteMember(String email);
 
-    Member updateMemberPassword(String id, String newPassword);
+    Member updateMemberPassword(String memberId, String newPassword);
 
     Member updateMemberStatus(String email, MemberStatus status);
 

--- a/src/main/java/org/sesac/slopedbe/member/service/MemberService.java
+++ b/src/main/java/org/sesac/slopedbe/member/service/MemberService.java
@@ -9,7 +9,7 @@ public interface MemberService {
 
     void checkDuplicateId(String memberId);
 
-    String findIdByEmail(String email);
+    String findMemberIdByEmail(String email);
 
     void deleteMember(String email);
 

--- a/src/main/java/org/sesac/slopedbe/member/service/MemberService.java
+++ b/src/main/java/org/sesac/slopedbe/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package org.sesac.slopedbe.member.service;
 
+import org.sesac.slopedbe.member.model.dto.request.IdRequest;
 import org.sesac.slopedbe.member.model.dto.request.RegisterMemberRequest;
 import org.sesac.slopedbe.member.model.entity.Member;
 import org.sesac.slopedbe.member.model.type.MemberStatus;
@@ -11,11 +12,11 @@ public interface MemberService {
 
     String findMemberIdByEmail(String email);
 
-    void deleteMember(String email);
+    void deleteMember(IdRequest idRequest);
 
     Member updateMemberPassword(String memberId, String newPassword);
 
-    Member updateMemberStatus(String email, MemberStatus status);
+    Member updateMemberStatus(IdRequest idRequest, MemberStatus status);
 
-    Member updateMemberInfo(String email, String newNickname, String newPassword, boolean newDisability);
+    Member updateMemberInfo(IdRequest idRequest, String newNickname, String newPassword, boolean newDisability);
 }

--- a/src/main/java/org/sesac/slopedbe/member/service/MemberServiceImpl.java
+++ b/src/main/java/org/sesac/slopedbe/member/service/MemberServiceImpl.java
@@ -25,8 +25,10 @@ public class MemberServiceImpl implements MemberService {
 
 	@Override
 	public Member registerMember(RegisterMemberRequest registerMemberRequest) {
+		// 회원 가입 DB 저장
 		String email = registerMemberRequest.email();
 
+		// email 기준, DB에 중복 이메일 검증
 		if (memberRepository.findByEmail(email).isPresent()) {
 			throw new MemberException(MemberErrorCode.MEMBER_EMAIL_ALREADY_EXISTS);
 		}
@@ -44,8 +46,11 @@ public class MemberServiceImpl implements MemberService {
 
 	@Override
 	public void checkDuplicateId(String memberId) {
+		// Id DB에서 검색, 중복 여부 확인
+
 		log.info("checkDuplicateId: {}", memberRepository.existsByMemberId(memberId));
 
+		// 중복이면 errorCode 발생
 		if(memberRepository.existsByMemberId(memberId)) {
 			throw new MemberException(MemberErrorCode.MEMBER_ID_ALREADY_EXISTS);
 		}
@@ -53,6 +58,7 @@ public class MemberServiceImpl implements MemberService {
 
 	@Override
 	public String findMemberIdByEmail(String email) {
+		// email로 검색 후, MemberId 반환
 		Member member = memberRepository.findByEmail(email)
 			.orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_ID_NOT_FOUND));
 		return member.getMemberId();
@@ -60,12 +66,13 @@ public class MemberServiceImpl implements MemberService {
 
 	@Override
 	public void deleteMember(String email) {
+		// DB에서 email 기준, 회원 정보 삭제
 		memberRepository.deleteByEmail(email);
 	}
 
 	@Override
 	public Member updateMemberPassword(String memberId, String newPassword) {
-		//비밀번호 모르는 경우, 인증번호 받아서 비밀번호 변경
+		//비밀번호 찾기, 메일 인증 후, 비밀번호 변경
 		Optional<Member> member = memberRepository.findByMemberId(memberId);
 		if (member.isPresent()) {
 			Member existingMember = member.get();
@@ -78,6 +85,7 @@ public class MemberServiceImpl implements MemberService {
 
 	@Override
 	public Member updateMemberStatus(String email, MemberStatus status) {
+		// 관리자 페이지, member status 변경
 		Optional<Member> member = memberRepository.findByEmail(email);
 		if (member.isEmpty()) {
 			throw new MemberException(MemberErrorCode.MEMBER_NOT_FOUND);
@@ -90,7 +98,7 @@ public class MemberServiceImpl implements MemberService {
 
 	@Override
 	public Member updateMemberInfo(String email, String newNickname, String newPassword, boolean newDisability) {
-		//마이페이지에서 회원정보 수정
+		//마이페이지, 회원정보 수정
 		Optional<Member> member = memberRepository.findByEmail(email);
 		if (member.isEmpty()) {
 			throw new MemberException(MemberErrorCode.MEMBER_NOT_FOUND);

--- a/src/main/java/org/sesac/slopedbe/member/service/MemberServiceImpl.java
+++ b/src/main/java/org/sesac/slopedbe/member/service/MemberServiceImpl.java
@@ -4,8 +4,11 @@ import java.util.Optional;
 
 import org.sesac.slopedbe.member.exception.MemberErrorCode;
 import org.sesac.slopedbe.member.exception.MemberException;
+import org.sesac.slopedbe.member.model.dto.request.IdRequest;
 import org.sesac.slopedbe.member.model.dto.request.RegisterMemberRequest;
 import org.sesac.slopedbe.member.model.entity.Member;
+import org.sesac.slopedbe.member.model.entity.MemberCompositeKey;
+import org.sesac.slopedbe.member.model.type.MemberOauthType;
 import org.sesac.slopedbe.member.model.type.MemberStatus;
 import org.sesac.slopedbe.member.repository.MemberRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -27,26 +30,29 @@ public class MemberServiceImpl implements MemberService {
 	public Member registerMember(RegisterMemberRequest registerMemberRequest) {
 		// 회원 가입 DB 저장
 		String email = registerMemberRequest.email();
+		MemberOauthType oauthType = MemberOauthType.LOCAL;
 
-		// email 기준, DB에 중복 이메일 검증
-		if (memberRepository.findByEmail(email).isPresent()) {
+		// email과 oauthType 기준, DB에 중복 검증
+		if (memberRepository.findById(new MemberCompositeKey(email, oauthType)).isPresent()) {
 			throw new MemberException(MemberErrorCode.MEMBER_EMAIL_ALREADY_EXISTS);
 		}
 
-		return memberRepository.save(
-			new Member(
-				registerMemberRequest.id(),
-				passwordEncoder.encode(registerMemberRequest.password()),
-				registerMemberRequest.email(),
-				registerMemberRequest.nickname(),
-				registerMemberRequest.isDisabled()
-		));
+		Member member = new Member(
+			registerMemberRequest.id(),
+			passwordEncoder.encode(registerMemberRequest.password()),
+			registerMemberRequest.email(),
+			registerMemberRequest.nickname(),
+			registerMemberRequest.isDisabled()
+		);
 
+		member.setOauthType(MemberOauthType.LOCAL);
+
+		return memberRepository.save(member);
 	}
 
 	@Override
 	public void checkDuplicateId(String memberId) {
-		// Id DB에서 검색, 중복 여부 확인
+		// MemberId DB에서 검색, 중복 여부 확인
 
 		log.info("checkDuplicateId: {}", memberRepository.existsByMemberId(memberId));
 
@@ -59,15 +65,26 @@ public class MemberServiceImpl implements MemberService {
 	@Override
 	public String findMemberIdByEmail(String email) {
 		// email로 검색 후, MemberId 반환
-		Member member = memberRepository.findByEmail(email)
+
+		// MemberId 찾는 method로, Type은 Local로 지정
+		MemberOauthType oauthType = MemberOauthType.LOCAL;
+
+		MemberCompositeKey compositeKey = new MemberCompositeKey(email, oauthType);
+		Member member = memberRepository.findById(compositeKey)
 			.orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_ID_NOT_FOUND));
 		return member.getMemberId();
 	}
 
 	@Override
-	public void deleteMember(String email) {
-		// DB에서 email 기준, 회원 정보 삭제
-		memberRepository.deleteByEmail(email);
+	public void deleteMember(IdRequest idRequest) {
+		// 마이페이지, 관리자 페이지 회원 정보 삭제
+
+		String email = idRequest.email();
+		MemberOauthType oauthType = idRequest.oauthType();
+
+		MemberCompositeKey compositeKey = new MemberCompositeKey(email, oauthType);
+
+		memberRepository.deleteById(compositeKey);
 	}
 
 	@Override
@@ -84,9 +101,13 @@ public class MemberServiceImpl implements MemberService {
 	}
 
 	@Override
-	public Member updateMemberStatus(String email, MemberStatus status) {
+	public Member updateMemberStatus(IdRequest idRequest, MemberStatus status) {
 		// 관리자 페이지, member status 변경
-		Optional<Member> member = memberRepository.findByEmail(email);
+
+		String email = idRequest.email();
+		MemberOauthType oauthType = idRequest.oauthType();
+
+		Optional<Member> member = memberRepository.findById(new MemberCompositeKey(email, oauthType));
 		if (member.isEmpty()) {
 			throw new MemberException(MemberErrorCode.MEMBER_NOT_FOUND);
 		}
@@ -97,9 +118,13 @@ public class MemberServiceImpl implements MemberService {
 	}
 
 	@Override
-	public Member updateMemberInfo(String email, String newNickname, String newPassword, boolean newDisability) {
+	public Member updateMemberInfo(IdRequest idRequest, String newNickname, String newPassword, boolean newDisability) {
 		//마이페이지, 회원정보 수정
-		Optional<Member> member = memberRepository.findByEmail(email);
+
+		String email = idRequest.email();
+		MemberOauthType oauthType = idRequest.oauthType();
+
+		Optional<Member> member = memberRepository.findById(new MemberCompositeKey(email, oauthType));
 		if (member.isEmpty()) {
 			throw new MemberException(MemberErrorCode.MEMBER_NOT_FOUND);
 		}

--- a/src/main/java/org/sesac/slopedbe/member/service/MemberServiceImpl.java
+++ b/src/main/java/org/sesac/slopedbe/member/service/MemberServiceImpl.java
@@ -52,7 +52,7 @@ public class MemberServiceImpl implements MemberService {
 	}
 
 	@Override
-	public String findIdByEmail(String email) {
+	public String findMemberIdByEmail(String email) {
 		Member member = memberRepository.findByEmail(email)
 			.orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_ID_NOT_FOUND));
 		return member.getMemberId();

--- a/src/main/java/org/sesac/slopedbe/member/service/MemberServiceImpl.java
+++ b/src/main/java/org/sesac/slopedbe/member/service/MemberServiceImpl.java
@@ -43,10 +43,10 @@ public class MemberServiceImpl implements MemberService {
 	}
 
 	@Override
-	public void checkDuplicateId(String id) {
-		log.info("checkDuplicateId: {}", memberRepository.existsByMemberId(id));
+	public void checkDuplicateId(String memberId) {
+		log.info("checkDuplicateId: {}", memberRepository.existsByMemberId(memberId));
 
-		if(memberRepository.existsByMemberId(id)) {
+		if(memberRepository.existsByMemberId(memberId)) {
 			throw new MemberException(MemberErrorCode.MEMBER_ID_ALREADY_EXISTS);
 		}
 	}
@@ -64,9 +64,9 @@ public class MemberServiceImpl implements MemberService {
 	}
 
 	@Override
-	public Member updateMemberPassword(String id, String newPassword) {
+	public Member updateMemberPassword(String memberId, String newPassword) {
 		//비밀번호 모르는 경우, 인증번호 받아서 비밀번호 변경
-		Optional<Member> member = memberRepository.findByMemberId(id);
+		Optional<Member> member = memberRepository.findByMemberId(memberId);
 		if (member.isPresent()) {
 			Member existingMember = member.get();
 			existingMember.setPassword(passwordEncoder.encode(newPassword));

--- a/src/main/java/org/sesac/slopedbe/roadreport/model/entity/RoadReport.java
+++ b/src/main/java/org/sesac/slopedbe/roadreport/model/entity/RoadReport.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinColumns;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -43,6 +44,9 @@ public class RoadReport extends BaseTimeEntity {
     private Road road;
 
     @ManyToOne
-    @JoinColumn(name = "email", nullable = false)
+    @JoinColumns({
+        @JoinColumn(name = "email", referencedColumnName = "email"),
+        @JoinColumn(name = "oauthType", referencedColumnName = "oauthType")
+    })
     private Member member;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
   jpa:
     generate-ddl: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:
@@ -38,6 +38,26 @@ spring:
     prefix: ${JWT_PREFIX}
     secret-key: ${JWT_SECRET_KEY}
 
+  security:
+    oauth2:
+      client:
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            user-name-attribute: id
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+        registration:
+          kakao:
+            client-name: kakao
+            authorization-grant-type: authorization_code
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            client-authentication-method: client_secret_post
+            scope:
+              - account_email
+
 ---
 
 spring:
@@ -57,7 +77,6 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
-
 
 logging:
   level:


### PR DESCRIPTION
## 240721 - Member 복합 키 변경

- merge 요청자: @

## 1. MR 목적

- 기존 Member PK : email에서 소셜 로그인 추가로, PK를 email, MemberOAuthType 복합키로 사용해 PR 요청

## 2. MR 내용

- 관련 Member Service, Verification Service, Login Service 수정
- Member Entity 복합키 추가
- 관련 Entity (FacilityReport, Bookmark, FacilityRegistrar) member 어노테이션 수정
- 관련 DB (member, bookmark, facility_registrar, facility_report, facility_review, road_report) FK 수정
