### PR TITLE
JWT 방식 변경

### DIFF
--- a/src/main/java/org/sesac/slopedbe/auth/controller/JwtController.java
+++ b/src/main/java/org/sesac/slopedbe/auth/controller/JwtController.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.sesac.slopedbe.auth.service.TokenAuthenticationService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.WebUtils;
@@ -33,15 +34,13 @@ public class JwtController {
 		@ApiResponse(responseCode = "401", description = "인증 실패"),
 		@ApiResponse(responseCode = "404", description = "존재하지 않는 회원")
 	})
-	@PostMapping(value = "/refresh-token")
-	public ResponseEntity<Map<String, String>> refreshToken(HttpServletRequest request, HttpServletResponse response) throws IOException {
-		Cookie expiredAccessTokenCookie = WebUtils.getCookie(request, "expiredAccessToken");
-		Cookie refreshTokenCookie = WebUtils.getCookie(request, "refreshToken");
+	@PostMapping(value = "/renew-token")
+	public ResponseEntity<Map<String, String>> renewToken(@RequestHeader("Authorization") String token, HttpServletRequest request, HttpServletResponse response) throws IOException {
+		String expiredAccessToken = token.substring(7);
 
-		String expiredAccessToken = expiredAccessTokenCookie.getValue();
+		Cookie refreshTokenCookie = WebUtils.getCookie(request, "refreshToken");
 		String refreshToken = refreshTokenCookie.getValue();
 
-		return tokenAuthenticationService.refreshToken(expiredAccessToken, refreshToken ,response);
+		return tokenAuthenticationService.renewToken(expiredAccessToken, refreshToken ,response);
 	}
-
 }

--- a/src/main/java/org/sesac/slopedbe/auth/controller/LoginController.java
+++ b/src/main/java/org/sesac/slopedbe/auth/controller/LoginController.java
@@ -48,7 +48,7 @@ public class LoginController {
 		IOException {
 
 		log.info("Login attempt for user: {}", loginRequest.memberId());
-		return tokenAuthenticationService.createAuthenticationToken(loginRequest, response);
+		return tokenAuthenticationService.localLoginToken(loginRequest, response);
 	}
 
 	@Operation(summary = "회원 가입", description = "소셜 유저 정보를 DB에 저장한다.")

--- a/src/main/java/org/sesac/slopedbe/auth/controller/SocialLoginController.java
+++ b/src/main/java/org/sesac/slopedbe/auth/controller/SocialLoginController.java
@@ -1,6 +1,8 @@
 package org.sesac.slopedbe.auth.controller;
 
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -12,6 +14,8 @@ import org.sesac.slopedbe.auth.service.SocialLoginService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -107,5 +111,19 @@ public class SocialLoginController {
 		KakaoUserInfoResponse userInfo = socialLoginService.getKakaoUserInfo(accessToken);
 
 		oAuth2UserService.loginSocialUser(userInfo.kakaoAccount.getEmail(),"kakao", response);
+	}
+
+	@PostMapping("/api/auth/exchange-token")
+	public ResponseEntity<Map<String, String>> exchangeToken(@RequestBody Map<String, String> request) {
+		String encodedToken = request.get("encodedToken");
+		if (encodedToken == null) {
+			return ResponseEntity.badRequest().body(Map.of("error", "Encoded token is required"));
+		}
+		try {
+			String decodedToken = URLDecoder.decode(encodedToken, StandardCharsets.UTF_8);
+			return ResponseEntity.ok(Map.of("accessToken", decodedToken));
+		} catch (Exception e) {
+			return ResponseEntity.badRequest().body(Map.of("error", "Failed to decode token"));
+		}
 	}
 }

--- a/src/main/java/org/sesac/slopedbe/auth/model/GeneralUserDetails.java
+++ b/src/main/java/org/sesac/slopedbe/auth/model/GeneralUserDetails.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.Map;
 
 import org.sesac.slopedbe.member.model.entity.Member;
+import org.sesac.slopedbe.member.model.type.MemberOauthType;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -63,7 +64,7 @@ public class GeneralUserDetails implements OAuth2User, UserDetails {
 		return true;
 	}
 
-	public String getUserOauthType() {
-		return this.member.getId().getOauthType().toString();
+	public MemberOauthType getUserOauthType() {
+		return this.member.getId().getOauthType();
 	}
 }

--- a/src/main/java/org/sesac/slopedbe/auth/service/FakeIdService.java
+++ b/src/main/java/org/sesac/slopedbe/auth/service/FakeIdService.java
@@ -1,0 +1,85 @@
+package org.sesac.slopedbe.auth.service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.sesac.slopedbe.member.model.entity.MemberCompositeKey;
+import org.sesac.slopedbe.member.model.type.MemberOauthType;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class FakeIdService {
+
+	@Value("${JWT_SECRET_KEY}")
+	private String secretKey;
+	private final Map<String, MemberCompositeKey> mapping;
+
+	public FakeIdService() {
+		this.mapping = new HashMap<>();
+	}
+
+	public String generateFakeId(String email, MemberOauthType oauthType) throws NoSuchAlgorithmException, InvalidKeyException {
+		String combinedString = email + ":" + oauthType.getValue();
+
+		Mac sha256Hmac = Mac.getInstance("HmacSHA256");
+		SecretKeySpec secretKeySpec = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+		sha256Hmac.init(secretKeySpec);
+
+		byte[] hashBytes = sha256Hmac.doFinal(combinedString.getBytes(StandardCharsets.UTF_8));
+		String base64Hash = Base64.getEncoder().encodeToString(hashBytes);
+
+		String fakeId = base64Hash.replace('+', '-')
+			.replace('/', '_')
+			.replace("=", "");
+
+		mapping.put(fakeId, new MemberCompositeKey(email, oauthType));
+
+		return fakeId;
+	}
+
+	public MemberCompositeKey decodeFakeId(String fakeId) throws IllegalArgumentException {
+		MemberCompositeKey memberKey = mapping.get(fakeId);
+		if (memberKey == null) {
+			throw new IllegalArgumentException("Invalid or unknown fake ID");
+		}
+		return memberKey;
+	}
+
+	public String extractEmailFromFakeId(String fakeId) {
+		try {
+			MemberCompositeKey memberKey = decodeFakeId(fakeId);
+			return memberKey.getEmail();
+		} catch (IllegalArgumentException e) {
+			log.error("Error decoding fake ID", e);
+			return null;
+		} catch (Exception e) {
+			log.error("Unexpected error while decoding fake ID", e);
+			return null;
+		}
+	}
+
+	public MemberOauthType extractOAuthTypeFromFakeId(String fakeId) {
+		try {
+			MemberCompositeKey memberKey = decodeFakeId(fakeId);
+			return memberKey.getOauthType();
+		} catch (IllegalArgumentException e) {
+			log.error("Error decoding fake ID", e);
+			return null;
+		} catch (Exception e) {
+			log.error("Unexpected error while decoding fake ID", e);
+			return null;
+		}
+	}
+
+}

--- a/src/main/java/org/sesac/slopedbe/facilityreview/controller/FacilityReviewController.java
+++ b/src/main/java/org/sesac/slopedbe/facilityreview/controller/FacilityReviewController.java
@@ -82,17 +82,4 @@ public class FacilityReviewController {
 
         return ResponseEntity.noContent().build();
     }
-
-
-
-
-
-
-
-
-
-
-
-
-
 }


### PR DESCRIPTION
## 1. MR 목적

- JWT 로직 변경

## 2. MR 내용

- Token은 email에서 fake-id라는 값으로 대체
- RefreshToken은 Cookie의 형태, AccessToken은 localStorage 저장 형태
